### PR TITLE
Plugin refactor so lines are passed as an argument

### DIFF
--- a/PLUGIN_DEVELOPMENT.md
+++ b/PLUGIN_DEVELOPMENT.md
@@ -17,11 +17,11 @@ Here's a basic template for a parser plugin:
     class MyPlugin {
 
         constructor(knowParser) {
-            this.instance = knowParser;
+            //optionally define a constructor
         }
 
-        main() {
-            const lines = this.instance.lines;
+        main(lines) {
+            // lines is equal to the knowParser's lines
             // parser code here
         }
     }
@@ -31,40 +31,34 @@ Here's a basic template for a parser plugin:
 
 ### Step by step explanation
 
-1. When you register your plugin via `knowParser.register()`, the parser instance is passed to your plugin, you should save this instance as it will give you access to the text to parse.
+1. When you register your plugin via `knowParser.register()`, the parser instance is passed to your plugin's constructor. This is usually for special cases, you probably won't need to define your own constructor unless you know what you're doing.
 
     ```javascript
         class MyPlugin {
             constructor(knowParser) {
-                this.instance = knowParser;
+                //do as you wish
             }
         }
     ```
 
-2. Every plugin must have a method called `main()`, this is the method that is called when running `knowParser.get("MyPlugin");`
+2. Every plugin must have a method called `main()`, this is the method that is called when running `knowParser.get("MyPlugin", ...[args]);`. The knowParser's lines are ALWAYS passed here as the first argument. Additional arguments passed in through .get will also be accessible.
 
     ```javascript
-        main() {
-            // the lines given to knowParser
-            const lines = this.instance.lines;
+        main(lines, myArg1) {
+            //if you called knowParser.get("MyPlugin", myArg1)
         }
     ```
 
-3. Your plugin should use the text given to knowParser (DO NOT MODIFY  THIS)
+3. Your plugin should return an array of results, usually by processing the lines array
 
-    ```javascript
-        knowParser.lines = "one\ntwo";
-        knowParser.get("MyPlugin");
+   ```javascript
+        const emails = knowParser.get("MyPluginThatDetectsEmails");
 
-        // knowParser.lines would be ["one", "two"]
+        // This is expected to return [] on no results, or full of results
+        console.log(emails);
     ```
 
-4. Your plugin should return an array of results
-
-    ```javascript
-        // returns [] on no result, or full of results
-        knowParser.get("MyPlugin");
-    ```
+    
 
 ## knowParser.register()
 
@@ -92,11 +86,7 @@ knowParser.lines = "here is some text";
 
 class MyPlugin {
 
-    constructor(knowParser) {
-        this.instance = knowParser;
-    }
-
-    main(foo, bar, baz) {
+    main(lines, foo, bar, baz) {
         return `Foo: ${foo}, Bar: ${bar}, Baz: ${baz}`;
     }
 }
@@ -115,14 +105,9 @@ If the given text is an array, then it is first joined with newlines before bein
 
 Please do not modify this inside of your plugin as it could cause problems for the other know-parser plugins.
 
-## Standards and Best Practices
+## Standards and Best Practices on submitting plugins
 
-A few simple guidelines you should try to follow:
-
-1. Your plugin should all be in one file, with one class
-2. You should not modify `knowParser.lines` within your plugin, if you wish to do something like splitting on each space, create a copy of this variable
-3. Your plugin should gather the knowParser text during the `main()` function call, in order to have the latest text changes
-4. Have fun!
+A plugin should generally be within one file and class, self contained, and ultimately geared towards solving 1 specific problem.
 
 ## Contributing
 

--- a/__tests__/knowParser.test.js
+++ b/__tests__/knowParser.test.js
@@ -194,14 +194,16 @@ describe("knowParser", () => {
         });
         it("should pass on arguments", () => {
             const parser = new knowParser();
+            parser.lines = ['some', 'lines'];
             const argsToPass = [123, 456, 789];
+            const expected = [parser.lines].concat(argsToPass);
 
             function TestPlugin() {}
             TestPlugin.prototype.main = jest.fn((foo, bar, baz) => []);
 
             parser.register(TestPlugin);
             parser.get("TestPlugin", argsToPass[0], argsToPass[1], argsToPass[2]);
-            expect(TestPlugin.prototype.main.mock.calls[0]).toEqual(argsToPass);
+            expect(TestPlugin.prototype.main.mock.calls[0]).toEqual(expected);
             expect(TestPlugin.prototype.main.mock.calls.length).toEqual(1);
         });
         it("should give the correct text to the plugin", () => {

--- a/__tests__/plugins_emails.test.js
+++ b/__tests__/plugins_emails.test.js
@@ -1,13 +1,6 @@
 const EmailPlugin = require("../src/plugins/emails.js");
 
 describe("emails_plugin", () => {
-    describe("constructor", () => {
-        it("should set instance param", () => {
-            const instance = "Not a real instance";
-            const plugin = new EmailPlugin(instance);
-            expect(plugin.instance).toBe(instance);
-        });
-    });
     describe("main", () => {
         it("should not call extractEmails on bad data", () => {
             const lines = ["foo", "bar"];

--- a/__tests__/plugins_emails.test.js
+++ b/__tests__/plugins_emails.test.js
@@ -10,33 +10,24 @@ describe("emails_plugin", () => {
     });
     describe("main", () => {
         it("should not call extractEmails on bad data", () => {
-            const instance = {lines:["foo", "bar"]};
-            const plugin = new EmailPlugin(instance);
+            const lines = ["foo", "bar"];
+            const plugin = new EmailPlugin();
             plugin.extractEmails = jest.fn(() => []);
 
-            plugin.main();
+            plugin.main(lines);
             expect(plugin.extractEmails.mock.calls.length).toEqual(0);
-        });
-        it("should give useful lines to extractEmails", () => {
-            const instance = {lines:["someemail@fakedomain.com"]};
-            const plugin = new EmailPlugin(instance);
-            plugin.extractEmails = jest.fn(() => []);
-
-            plugin.main();
-            expect(plugin.extractEmails.mock.calls.length).toEqual(1);
         });
         it("should return results", () => {
             const emails = [
                 "knowparser@implink.org",
                 "notarealemail@somefakedomain.com"
             ];
-            const instance = {lines:emails};
-            const plugin = new EmailPlugin(instance);
+            const plugin = new EmailPlugin();
             plugin.extractEmails = jest.fn();
             plugin.extractEmails.mockImplementationOnce(jest.fn(() => [emails[0]]));
             plugin.extractEmails.mockImplementationOnce(jest.fn(() => [emails[1]]));
 
-            expect(plugin.main()).toEqual(emails);
+            expect(plugin.main(emails)).toEqual(emails);
             expect(plugin.extractEmails.mock.calls.length).toEqual(2);
         });
         it("should not return bad data", () => {
@@ -44,11 +35,10 @@ describe("emails_plugin", () => {
                 "knowparser@implink.org",
                 "this is not an email address"
             ];
-            const instance = {lines:lines};
-            const plugin = new EmailPlugin(instance);
+            const plugin = new EmailPlugin();
             plugin.extractEmails = jest.fn(() => [lines[0]]);
 
-            expect(plugin.main()).toEqual([lines[0]]);
+            expect(plugin.main(lines)).toEqual([lines[0]]);
             expect(plugin.extractEmails.mock.calls.length).toEqual(1);
         });
     });

--- a/__tests__/plugins_phones.test.js
+++ b/__tests__/plugins_phones.test.js
@@ -1,13 +1,6 @@
 const PhonesPlugin = require("../src/plugins/phones.js");
 
 describe("phoneNumbers_plugin", () => {
-    describe("constructor", () => {
-        it("should set instance param", () => {
-            const instance = "Not a real instance";
-            const plugin = new PhonesPlugin(instance);
-            expect(plugin.instance).toBe(instance);
-        });
-    });
     describe("main", () => {
         it("should not call grabHrefTel on bad data", () => {
             const lines = ["foo", "bar"];

--- a/__tests__/plugins_phones.test.js
+++ b/__tests__/plugins_phones.test.js
@@ -10,19 +10,19 @@ describe("phoneNumbers_plugin", () => {
     });
     describe("main", () => {
         it("should not call grabHrefTel on bad data", () => {
-            const instance = {lines:["foo", "bar"]};
-            const plugin = new PhonesPlugin(instance);
+            const lines = ["foo", "bar"];
+            const plugin = new PhonesPlugin();
             plugin.grebHrefTel = jest.fn(() => []);
 
-            plugin.main();
+            plugin.main(lines);
             expect(plugin.grebHrefTel.mock.calls.length).toEqual(0);
         });
         it("should give useful lines to grabHrefTel", () => {
-            const instance = {lines:["tel:'+44 1632 960983'"]};
-            const plugin = new PhonesPlugin(instance);
+            const lines = ["tel:'+44 1632 960983'"];
+            const plugin = new PhonesPlugin();
             plugin.grabHrefTel = jest.fn();
 
-            plugin.main();
+            plugin.main(lines);
             expect(plugin.grabHrefTel.mock.calls.length).toEqual(1);
         });
         it("should return results", () => {
@@ -30,12 +30,11 @@ describe("phoneNumbers_plugin", () => {
                 "href='tel:+44 1632 960983'",
                 "+44 1632 960984"
             ];
-            const instance = {lines:phones};
-            const plugin = new PhonesPlugin(instance);
+            const plugin = new PhonesPlugin();
             plugin.grabHrefTel = jest.fn(() => phones[0].split("tel:")[1].split("'")[0]);
             plugin.validate = jest.fn(() => [phones[1]]);
 
-            expect(plugin.main()).toEqual(
+            expect(plugin.main(phones)).toEqual(
                 [
                     phones[0].split("tel:")[1].split("'")[0].replace(/\s/g, ""),
                     phones[1].replace(/\s/g, "")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "know-parser",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A simple, plugin-based parser for text",
   "repository": {
     "type": "git",

--- a/src/knowParser.js
+++ b/src/knowParser.js
@@ -101,8 +101,10 @@ class KnowParser {
             return [];
         }
 
+        //We will pass each plugin a clone of .lines for safety
+        const lines = Array.from(this.lines);
         try {
-            return this._plugins[pluginName].main(...args);
+            return this._plugins[pluginName].main(lines, ...args);
         } catch (err) {
             throw new Error(`know-parser plugin '${pluginName}' error: ${err}`);
         }

--- a/src/plugins/emails.js
+++ b/src/plugins/emails.js
@@ -5,8 +5,8 @@ class KnowEmails {
         this.instance = knowParser;
     }
 
-    main() {
-        const lineList = this.instance.lines;
+    main(lines) {
+        const lineList = lines;
         const emails = [];
 
         for (let i = 0; i < lineList.length; i++) {

--- a/src/plugins/emails.js
+++ b/src/plugins/emails.js
@@ -1,9 +1,5 @@
+const regex = /(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))/g;
 class KnowEmails {
-
-    constructor(knowParser) {
-        this.emailRegex = /(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))/g;
-        this.instance = knowParser;
-    }
 
     main(lines) {
         const lineList = lines;
@@ -36,7 +32,7 @@ class KnowEmails {
         }
 
         const results = [];
-        const match = query.match(this.emailRegex);
+        const match = query.match(regex);
         if (match) {
             results.push(...match);
         }

--- a/src/plugins/phones.js
+++ b/src/plugins/phones.js
@@ -27,8 +27,8 @@ class KnowPhones {
      * @returns  {Array}  All the numbers found
      * @memberof KnowPhones
      */
-    main() {
-        const lineList = this.instance.lines;
+    main(lines) {
+        const lineList = lines;
         const numsFound = [];
 
         for (let i = 0; i < lineList.length; i++) {

--- a/src/plugins/phones.js
+++ b/src/plugins/phones.js
@@ -4,22 +4,12 @@
  * @class PhoneNumbers
  * @author George Meadows
  */
+const regex = [
+    /(\+[0-9]{2}|^\+[0-9]{2}\(0\)|^\(\+[0-9]{2}\)\(0\)|^00[0-9]{2}|^0)([0-9]{9}$|[0-9\-\s]{10,13})/g,
+    /(([+]\d{2}[ ][1-9]\d{0,2}[ ])|([0]\d{1,3}[-]))((\d{2}([ ]\d{2}){2})|(\d{3}([ ]\d{3})*([ ]\d{2})+))/g,
+    /[+]44(7|1)\d{9}/g
+];
 class KnowPhones {
-
-    /**
-     * Creates an instance of PhoneNumbers.
-     * Also creates our regex etc.
-     * @param {KnowParser}  knowInstance  The KnowParser instance
-     * @memberof KnowPhones
-     */
-    constructor(knowInstance) {
-        this.regex = [
-            /(\+[0-9]{2}|^\+[0-9]{2}\(0\)|^\(\+[0-9]{2}\)\(0\)|^00[0-9]{2}|^0)([0-9]{9}$|[0-9\-\s]{10,13})/g,
-            /(([+]\d{2}[ ][1-9]\d{0,2}[ ])|([0]\d{1,3}[-]))((\d{2}([ ]\d{2}){2})|(\d{3}([ ]\d{3})*([ ]\d{2})+))/g,
-            /[+]44(7|1)\d{9}/g
-        ];
-        this.instance = knowInstance;
-    }
 
     /**
      * Gathers phone numbers from a string
@@ -81,8 +71,8 @@ class KnowPhones {
      */
     validate(line) {
         const results = [];
-        for (let x = 0; x < this.regex.length; x++) {
-            const currentRegex = this.regex[x];
+        for (let x = 0; x < regex.length; x++) {
+            const currentRegex = regex[x];
             const matches = line.match(currentRegex) || line.replace(/-/g, "").match(currentRegex);
             if (matches) {
                 results.push(...matches.map(num => num.replace(/-/g, "")));


### PR DESCRIPTION
I believe there's a lot of assumption and hope that a plugin developer won't mess around with the know-parser instance, and by extension the .lines property, passed to it.

With these changes a plugin's main() method will always be passed a clone of the .lines array as its first parameter, eliminating this assumption.

This also should shorten a lot of plugins, which will now have no need to define their own custom constructor.