### PR TITLE
New plugin KnowLinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ const phones = knowParser.get('phones');
 console.log(phones); // An array of phone numbers
 ```
 
+### links
+
+```javascript
+const links = knowParser.get('links');
+console.log(links); // An array of links (starting with http/https/www)
+```
+
 ## Developing Parser Plugins
 
 Because of the plugin-based nature of this package, it's surprisingly simple to create your own plugins for know-parser.

--- a/__tests__/functional/plugins.js
+++ b/__tests__/functional/plugins.js
@@ -15,6 +15,7 @@ async function main() {
 
         console.log(`PHONES: ${instance.get("phones")}`);
         console.log(`EMAILS: ${instance.get("emails")}`);
+        console.log(`LINKS: ${JSON.stringify(instance.get("links"), null, 2)}`);
         console.log("\n");
     }
 }

--- a/__tests__/plugins_links.test.js
+++ b/__tests__/plugins_links.test.js
@@ -1,0 +1,78 @@
+const LinksPlugin = require("../src/plugins/links.js");
+
+describe("links_plugin", () => {
+    describe("main", () => {
+        it("should call grabURL", () => {
+            const lines = [
+                "foo",
+                "bar"
+            ];
+            const plugin = new LinksPlugin();
+            plugin.grabURL = jest.fn(() => []);
+
+            plugin.main(lines);
+            expect(plugin.grabURL.mock.calls.length).toEqual(lines.length);
+        });
+        it("should return results", () => {
+            const lines = [
+                "https://www.google.com",
+                "www.example.com"
+            ];
+            const plugin = new LinksPlugin();
+            plugin.grabURL = jest.fn((line) => [line]);
+
+            expect(plugin.main(lines)).toEqual(lines);
+        });
+        it("should not return duplicates", () => {
+            const lines = [
+                "www.example.com",
+                "www.example.com",
+                "https://www.google.com",
+            ];
+            const plugin = new LinksPlugin();
+            plugin.grabURL = jest.fn((line) => [line]);
+
+            expect(plugin.main(lines)).toEqual(lines.slice(1));
+        });
+        it("should return an empty array on no data", () => {
+            const lines = [
+                "foo",
+                "bar"
+            ];
+            const plugin = new LinksPlugin();
+            plugin.grabURL = jest.fn(() => []);
+
+            expect(plugin.main(lines)).toEqual([]);
+        });
+    });
+    describe("grabURL", () => {
+        it("should return urls", () => {
+            const lines = [
+                "https://www.google.com",
+                "http://somewebsite.org",
+                "www.example.com",
+                "https://anotherwebsite.nl",
+                "http://onemorewebsite.co.uk"
+            ];
+
+            const plugin = new LinksPlugin();
+
+            for (let i = 0; i < lines.length; i++) {
+                const currentLine = lines[i];
+                expect(plugin.grabURL(currentLine)).toEqual([currentLine]);
+            }
+        });
+        it("should return multiple urls", () => {
+            const lines = "https://www.google.com http://somewebsite.org www.example.com https://anotherwebsite.nl http://onemorewebsite.co.uk";
+
+            const plugin = new LinksPlugin();
+            expect(plugin.grabURL(lines)).toEqual(lines.split(" "));
+        });
+        it("should return an empty array on no results", () => {
+            const line = "foo bar";
+
+            const plugin = new LinksPlugin();
+            expect(plugin.grabURL(line)).toEqual([]);
+        });
+    });
+});

--- a/__tests__/plugins_phones.test.js
+++ b/__tests__/plugins_phones.test.js
@@ -1,22 +1,14 @@
 const PhonesPlugin = require("../src/plugins/phones.js");
 
-describe("phoneNumbers_plugin", () => {
+describe("phones_plugin", () => {
     describe("main", () => {
-        it("should not call grabHrefTel on bad data", () => {
-            const lines = ["foo", "bar"];
-            const plugin = new PhonesPlugin();
-            plugin.grebHrefTel = jest.fn(() => []);
-
-            plugin.main(lines);
-            expect(plugin.grebHrefTel.mock.calls.length).toEqual(0);
-        });
         it("should call grabHrefTel", () => {
             const lines = ["tel:'+44 1632 960983'"];
             const plugin = new PhonesPlugin();
             plugin.grabHrefTel = jest.fn();
 
             plugin.main(lines);
-            expect(plugin.grabHrefTel.mock.calls.length).toEqual(1);
+            expect(plugin.grabHrefTel.mock.calls.length).toEqual(lines.length);
         });
         it("should return results", () => {
             const phones = [
@@ -35,6 +27,15 @@ describe("phoneNumbers_plugin", () => {
             );
             expect(plugin.grabHrefTel.mock.calls.length).toEqual(phones.length);
             expect(plugin.validate.mock.calls.length).toEqual(phones.length);
+        });
+        it("should return an empty array on no results", () => {
+            const lines = [
+                "foo",
+                "bar"
+            ];
+            const plugin = new PhonesPlugin();
+
+            expect(plugin.main(lines)).toEqual([]);
         });
     });
     describe("grabHrefTel", () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "know-parser",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A simple, plugin-based parser for text",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "main": "./src/knowParser.js",
   "scripts": {
-    "test": "jshint ./src && jest ./__tests__/*.test.js"
+    "test": "jshint ./src && jest --verbose ./__tests__/*.test.js"
   },
   "keywords": [
     "data",

--- a/src/plugins/emails.js
+++ b/src/plugins/emails.js
@@ -51,12 +51,8 @@ class KnowEmails {
             return [];
         }
 
-        const results = [];
-        const match = query.match(regex);
-        if (match) {
-            results.push(...match);
-        }
-        return results;
+        const results = query.match(regex);
+        return results || [];
     }
 }
 

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -1,4 +1,5 @@
 module.exports = {
     "phones": require("./phones.js"),
-    "emails": require("./emails.js")
+    "emails": require("./emails.js"),
+    "links": require("./links.js")
 };

--- a/src/plugins/links.js
+++ b/src/plugins/links.js
@@ -1,0 +1,47 @@
+/**
+ * Extracts links found in a piece of text
+ *
+ * @class KnowLinks
+ * @author George Meadows
+ */
+class KnowLinks {
+
+    /**
+     * Returns an array of links found in the text.
+     * Duplicates removed.
+     *
+     * @param {Array}  lines  Lines from know-parser
+     * @returns
+     * @memberof KnowLinks
+     */
+    main(lines) {
+        const links = [];
+        for (let i = 0; i < lines.length; i++) {
+            const currentLine = lines[i];
+
+            links.push(...this.grabURL(currentLine));
+        }
+
+        return [
+            ... new Set(links)
+        ];
+    }
+
+    /**
+     * Runs regex on a line, returning links found.
+     *
+     * @param {String}  line  A line of text
+     * @returns {Array}       All links found
+     * @memberof KnowLinks
+     */
+    grabURL(line) {
+        // looking at urls starting with either
+        // https, http or www as others are too broad (e.g. window.href)
+        const regex = /(https:\/\/|http:\/\/|www\.)[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/ig;
+        const results = line.match(regex);
+
+        return results || [];
+    }
+}
+
+module.exports = KnowLinks;


### PR DESCRIPTION
A new plugin to gather links found in a piece of text (removing duplicates)

Note that this only grabs links starting with either www, http or https as others are way too broad (e.g. grabbing window.href)
