### PR TITLE
Adds a semi-colon into links regex

### DIFF
--- a/src/plugins/links.js
+++ b/src/plugins/links.js
@@ -40,7 +40,7 @@ class KnowLinks {
     grabURL(line) {
         // looking at urls starting with either
         // https, http or www as others are too broad (e.g. window.href)
-        const regex = /(https:\/\/|http:\/\/|www\.)[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/ig;
+        const regex = /(https:\/\/|http:\/\/|www\.)[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:;%_\+.~#?&//=]*)/ig;
         const results = line.match(regex);
 
         return results || [];


### PR DESCRIPTION
For hostname bakermckenzie.com we were only scraping 
http://www.linkedin.com/company/baker-&amp
Which is not the full address - this fix's the problem