### PR TITLE
Don't collect emails starting with single quote

### DIFF
--- a/src/plugins/emails.js
+++ b/src/plugins/emails.js
@@ -1,4 +1,4 @@
-const regex = /(([^<>()\[\]\\.,;:\s@"\/?=]+(?!png|jpg|jpeg|zvg)(\.[^<>()\[\]\\.,;:\s@"\/=?]+)*(?!png|jpg|jpeg|zvg)))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+((?!png|jpg|jpeg|zvg)[a-zA-Z]{2,})))/gi;
+const regex = /(([^<>()\[\]\\.,;:\s@"'\/?=]+(?!png|jpg|jpeg|zvg)(\.[^<>()\[\]\\.,;:\s@"\/=?]+)*(?!png|jpg|jpeg|zvg)))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+((?!png|jpg|jpeg|zvg)[a-zA-Z]{2,})))/gi;
 /**
  * A know-parser plugin to gather email addresses
  *


### PR DESCRIPTION
Unit tests all passed.
Fixes the following error, for hostname: 'investor.esprinet.com/sala-stampa/' we have in the HTML

onclick="$('#destinatario').val('investor@esprinet.com');

we want to grab the email address and ignore the quote marks surrounding it.